### PR TITLE
Explicitly use OpenSSL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ pip install blockchainauth
 >>> from blockchainauth import AuthRequest
 >>> from pybitcoin import BitcoinPrivateKey
 >>> private_key = BitcoinPrivateKey(compressed=True)
->>> auth_request = AuthRequest(private_key.to_pem(), private_key.public_key().to_hex(), 'onename.com', permissions=['public-profile'])
+>>> auth_request = AuthRequest(private_key.to_pem(), private_key.public_key().to_hex(), 'onename.com', permissions=['blockchainid'])
 >>> auth_request_token = auth_request.token()
 >>> print auth_request_token
 eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3N1ZWRBdCI6IjE0NDA3MTM0MTQuMTkiLCJjaGFsbGVuZ2UiOiIxZDc4NTBkNy01YmNmLTQ3ZDAtYTgxYy1jMDA4NTc5NzY1NDQiLCJwZXJtaXNzaW9ucyI6WyJibG9ja2NoYWluaWQiXSwiaXNzdWVyIjp7InB1YmxpY0tleSI6IjAzODI3YjZhMzRjZWJlZTZkYjEwZDEzNzg3ODQ2ZGVlYWMxMDIzYWNiODNhN2I4NjZlMTkyZmEzNmI5MTkwNjNlNCIsImRvbWFpbiI6Im9uZW5hbWUuY29tIn19.96Q_O_4DX8uPy1enosEwS2sIcyVelWhxvfj2F8rOvHldhqt9YRYilauepb95DVnmpqpCXxJb7jurT8auNCbptw

--- a/blockchainauth/keys.py
+++ b/blockchainauth/keys.py
@@ -6,7 +6,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.serialization import (
     load_der_private_key, load_pem_private_key, load_der_public_key,
     load_pem_public_key
@@ -31,11 +31,11 @@ def load_signing_key(signing_key):
 
         try:
             return load_der_private_key(
-                signing_key, password=None, backend=default_backend())
+                signing_key, password=None, backend=backend)
         except:
             try:
                 return load_pem_private_key(
-                    signing_key, password=None, backend=default_backend())
+                    signing_key, password=None, backend=backend)
             except Exception as e:
                 raise ValueError(
                     'Signing key must be a valid private key PEM or DER.')

--- a/blockchainauth/tokenizer.py
+++ b/blockchainauth/tokenizer.py
@@ -12,7 +12,7 @@ import binascii
 import traceback
 from collections import Mapping
 
-from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.serialization import (
     load_der_private_key, load_pem_private_key, load_der_public_key,
@@ -78,11 +78,11 @@ class Tokenizer():
         elif isinstance(verifying_key, (str, unicode)):
             try:
                 return load_der_public_key(
-                    verifying_key, backend=default_backend())
+                    verifying_key, backend=backend)
             except:
                 try:
                     return load_pem_public_key(
-                        verifying_key, backend=default_backend())
+                        verifying_key, backend=backend)
                 except Exception as e:
                     traceback.print_exc()
                     raise ValueError('Invalid verifying key format')

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -13,7 +13,7 @@ import traceback
 import unittest
 from test import test_support
 from pybitcoin import BitcoinPrivateKey
-from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import (
     EllipticCurvePrivateKey, EllipticCurvePublicKey


### PR DESCRIPTION
On my system `default_backend` appears to be a MultiBackend that can't handle EC keys, so it's probably backed by CommonCrypto. This explicitly uses the OpenSSL backend, which successfully loads ECDSA keys.

Also fixed an incorrect permission in the README.
